### PR TITLE
Rename gem to omniauth-1dtouch-music

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Omniauth::Music
+# Omniauth::OnedtouchMusic
 
 This gem contains the OmniAuth strategy to authenticate against http://music.1touch.com.
 
@@ -15,31 +15,32 @@ You should have an API Key and API Secret for Music app. This is what your web a
 First start by adding this gem to your Gemfile:
 
 ```ruby
-gem 'omniauth-music'
+gem 'omniauth-1dtouch-music'
 ```
 
 If you need to use the latest HEAD version, you can do so with:
 
 ```ruby
-gem 'omniauth-music', :github => 'craftsmen/omniauth-music'
+gem 'omniauth-1dtouch-music', :github => 'craftsmen/omniauth-1dtouch-music'
 ```
 
 Next, tell OmniAuth about this provider. For a Rails app, your `config/initializers/omniauth.rb` file should look like this:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :music, "API_KEY", "API_SECRET"
+  provider :onedtouch_music, "API_KEY", "API_SECRET"
 end
 ```
 
 Replace `"API_KEY"` and `"API_SECRET"` with the appropriate values.
 
 ## Authentication Hash
+
 An example auth hash available in `request.env['omniauth.auth']`:
 
 ```ruby
 {
-  provider: "music",
+  provider: "onedtouch_music",
   uid: "123456",
   info: {
     name: "Jim Morrison",
@@ -61,7 +62,7 @@ An example auth hash available in `request.env['omniauth.auth']`:
 
 ## Supported Rubies
 
-OmniAuth Music is tested under 2.2.1.
+Tested under 2.2.1.
 
 ## License
 

--- a/lib/omniauth-1dtouch-music.rb
+++ b/lib/omniauth-1dtouch-music.rb
@@ -1,0 +1,2 @@
+require 'omniauth/1dtouch-music/version'
+require 'omniauth/strategies/1dtouch-music'

--- a/lib/omniauth-music.rb
+++ b/lib/omniauth-music.rb
@@ -1,2 +1,0 @@
-require 'omniauth/music/version'
-require 'omniauth/strategies/music'

--- a/lib/omniauth/1dtouch-music/version.rb
+++ b/lib/omniauth/1dtouch-music/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
-  module Music
+  module OnedtouchMusic
     VERSION = '1.0.0'
   end
 end

--- a/lib/omniauth/music.rb
+++ b/lib/omniauth/music.rb
@@ -1,2 +1,0 @@
-require 'omniauth/music/version'
-require 'omniauth/strategies/music'

--- a/lib/omniauth/strategies/1dtouch-music.rb
+++ b/lib/omniauth/strategies/1dtouch-music.rb
@@ -2,8 +2,8 @@ require 'omniauth-oauth2'
 
 module OmniAuth
   module Strategies
-    class Music < OmniAuth::Strategies::OAuth2
-      option :name, 'music'
+    class OnedtouchMusic < OmniAuth::Strategies::OAuth2
+      option :name, 'onedtouch_music'
 
       option :client_options, site: 'http://music.1dtouch.com',
                               authorize_url: '/oauth/authorize'

--- a/omniauth-1dtouch-music.gemspec
+++ b/omniauth-1dtouch-music.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'omniauth/music/version'
+require 'omniauth/1dtouch-music/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'omniauth-music'
-  spec.version       = OmniAuth::Music::VERSION
+  spec.name          = 'omniauth-1dtouch-music'
+  spec.version       = OmniAuth::OnedtouchMusic::VERSION
   spec.authors       = ['Sébastien Charrier']
   spec.email         = ['sebastien@craftsmen.io']
 

--- a/spec/omniauth/1dtouch_music_spec.rb
+++ b/spec/omniauth/1dtouch_music_spec.rb
@@ -1,0 +1,13 @@
+describe OmniAuth::OnedtouchMusic do
+  it 'has a version number' do
+    expect(OmniAuth::OnedtouchMusic::VERSION).not_to be nil
+  end
+
+  it 'can be loaded by Omniauth' do
+    expect do
+      OmniAuth::Builder.new(nil) do
+        provider :onedtouch_music, 'aaa', 'bbb'
+      end
+    end.to_not raise_error
+  end
+end

--- a/spec/omniauth/music_spec.rb
+++ b/spec/omniauth/music_spec.rb
@@ -1,5 +1,0 @@
-describe OmniAuth::Music do
-  it 'has a version number' do
-    expect(OmniAuth::Music::VERSION).not_to be nil
-  end
-end

--- a/spec/omniauth/strategies/1dtouch_music_spec.rb
+++ b/spec/omniauth/strategies/1dtouch_music_spec.rb
@@ -1,7 +1,7 @@
-describe OmniAuth::Strategies::Music do
+describe OmniAuth::Strategies::OnedtouchMusic do
   describe 'configuration' do
     it 'returns correct name' do
-      expect(stubbed_strategy.options.name).to eq('music')
+      expect(stubbed_strategy.options.name).to eq('onedtouch_music')
     end
 
     it 'returns correct default site' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,4 +12,4 @@ require 'webmock/rspec'
 
 Dir["#{__dir__}/support/**/*.rb"].each { |file| require file }
 
-require 'omniauth/music'
+require 'omniauth-1dtouch-music'

--- a/spec/support/helpers/strategies_helper.rb
+++ b/spec/support/helpers/strategies_helper.rb
@@ -1,6 +1,6 @@
 module StrategiesHelper
   def stubbed_strategy(*args)
-    OmniAuth::Strategies::Music.new(nil, *args).tap do |strategy|
+    OmniAuth::Strategies::OnedtouchMusic.new(nil, *args).tap do |strategy|
       allow(strategy).to receive(:request) {
         request
       }


### PR DESCRIPTION
As we cannot start class names and symbols by a number, we had to use `OnedtouchMusic` and `onedtouch_music` instead.

Edit : I'll rename the repo once it's reviewed/merged.
